### PR TITLE
Add meta via asset function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+rss.zip
+zips

--- a/README.md
+++ b/README.md
@@ -2,12 +2,4 @@
 
 This plugin allows you to add RSS feeds to all your folders. 
 
-In the theme you additionally should add the following to your HTML head:
-
-```
-{% if item.elementType == 'folder' %}
-  <link rel="alternate" type="application/rss+xml" title="{{ title }}" href="{{ item.urlAbs }}/rss" />
-{% endif %}
-```
-
 Also a generic RSS feed with all posts from all folders is available just add `/rss` to your base url. The title and description of this generic RSS feed can be set in the plugin settings.

--- a/rss.php
+++ b/rss.php
@@ -17,7 +17,8 @@ class rss extends Plugin
 			'onPagePublished'		=> 'onPagePublished',
 			'onPageUnpublished'		=> 'onPageUnpublished',
 			'onPageSorted'			=> 'onPageSorted',
-			'onPageDeleted'			=> 'onPageDeleted'
+			'onPageDeleted'			=> 'onPageDeleted',
+            'onPageReady'           => 'onPageReady'
         );
     }
 
@@ -38,6 +39,11 @@ class rss extends Plugin
 	{
 		$this->updateRssXmls();
 	}
+    public function onPageReady()
+    {
+#        $this->addMeta('rss', '<link rel="alternate" type="application/rss+xml" title="{{ title }}" href="{{ item.urlAbs }}/rss" />');
+        $this->addMeta('rss', '<link rel="alternate" type="application/rss+xml">');
+    }
 
     public static function addNewRoutes()
     {

--- a/rss.php
+++ b/rss.php
@@ -39,10 +39,14 @@ class rss extends Plugin
 	{
 		$this->updateRssXmls();
 	}
-    public function onPageReady()
+    public function onPageReady($pagedata)
     {
-#        $this->addMeta('rss', '<link rel="alternate" type="application/rss+xml" title="{{ title }}" href="{{ item.urlAbs }}/rss" />');
-        $this->addMeta('rss', '<link rel="alternate" type="application/rss+xml">');
+        $data = $pagedata->getData();
+
+        if(isset($data['item']->folderContent) && is_array($data['item']->folderContent))
+        {
+            $this->addMeta('rss', '<link rel="alternate" type="application/rss+xml" title="' . $data['title'] . '" href="' . $data['item']->urlAbs . '/rss">');
+        }
     }
 
     public static function addNewRoutes()


### PR DESCRIPTION
Hi Andreas, 

you can add new meta-data with the asset function to keep the templates in a theme untouched. Introduced in version 1.5.2 and themes have been changed accordingly: https://typemill.net/news/version-1-5-2-visual-shortcodes

Do you want to review and merge if ok in your eyes?